### PR TITLE
feat: move to clap and update arguments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,6 +10,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "assert_cmd"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -20,6 +29,17 @@ dependencies = [
  "predicates-core",
  "predicates-tree",
  "wait-timeout",
+]
+
+[[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -36,12 +56,12 @@ checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
 name = "cargo-semver"
-version = "1.0.0-alpha.1"
+version = "1.0.0-alpha.2"
 dependencies = [
  "assert_cmd",
+ "clap",
  "predicates",
  "regex",
- "seahorse",
  "semver",
  "tempfile",
 ]
@@ -51,6 +71,21 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "clap"
+version = "2.33.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
+dependencies = [
+ "ansi_term",
+ "atty",
+ "bitflags",
+ "strsim",
+ "textwrap",
+ "unicode-width",
+ "vec_map",
+]
 
 [[package]]
 name = "difference"
@@ -82,6 +117,15 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi",
+]
+
+[[package]]
+name = "hermit-abi"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "322f4de77956e22ed0e5032c359a0f1273f1f7f0d79bfa3b8ffbc730d7fbcc5c"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -238,12 +282,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "seahorse"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce7d9440e2865cce0db733bdc530591b37d37a2d32badace34a1fc9ba5686d58"
-
-[[package]]
 name = "semver"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -262,6 +300,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+
+[[package]]
 name = "tempfile"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -273,6 +317,15 @@ dependencies = [
  "redox_syscall",
  "remove_dir_all",
  "winapi",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+dependencies = [
+ "unicode-width",
 ]
 
 [[package]]
@@ -295,6 +348,18 @@ name = "ucd-trie"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
+
+[[package]]
+name = "vec_map"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "wait-timeout"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Filip Stefansson <filip.stefansson@gmail.com>"]
 name = "cargo-semver"
-version = "1.0.0-alpha.1"
+version = "1.0.0-alpha.2"
 license = "MIT"
 description = "Cargo subcommand to update the version in your Cargo.toml file - SemVer style."
 readme = "README.md"
@@ -12,7 +12,7 @@ exclude = [".github"]
 edition = "2018"
 
 [dependencies]
-seahorse = "1.1"
+clap = "2.33.3"
 semver = "0.11.0"
 regex = "1"
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 $ cargo semver
 1.0.0
 
-$ cargo semver patch
+$ cargo semver bump patch
 1.0.1
 ```
 
@@ -25,7 +25,7 @@ $ cargo install cargo-semver
 
 ```console
 $ cargo semver # gets the current version
-$ cargo semver major|minor|patch|pre # bumps the version
+$ cargo semver bump [TYPE] [PRE-RELEASE] # bumps the version
 $ cargo set [VERSION] # sets a specific version
 ```
 
@@ -34,23 +34,23 @@ $ cargo set [VERSION] # sets a specific version
 You can update the version in your `Cargo.toml` file using one of the subcommands:
 
 ```console
-$ cargo semver major
+$ cargo semver bump major
 2.0.0
 
-$ cargo semver minor
+$ cargo semver bump minor
 2.1.0
 
-$ cargo semver patch
+$ cargo semver bump patch
 2.1.1
 
-$ cargo semver pre alpha
+$ cargo semver bump pre alpha
 2.1.1-alpha.1
 ```
 
-If you want to bump the version and add a pre-release version in one command you can use the `pre` flag:
+If you want to bump the version and add a pre-release version:
 
 ```console
-$ cargo semver major --pre alpha
+$ cargo semver bump major alpha
 2.0.0-alpha.1
 ```
 
@@ -59,16 +59,16 @@ $ cargo semver major --pre alpha
 There are multiple ways of updating the pre-release version:
 
 ```console
-$ cargo semver major --pre alpha
+$ cargo semver bump major alpha
 2.0.0-alpha.1
 
-$ cargo semver pre alpha
+$ cargo semver bump pre alpha
 2.0.0-alpha.2
 
-$ cargo semver pre
+$ cargo semver bump pre
 2.0.0-alpha.3
 
-$ cargo semver pre beta
+$ cargo semver bump pre beta
 2.0.0-beta.1
 ```
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,219 +1,96 @@
 mod config;
 mod version;
 
-use seahorse::{App, Command, Context, Flag, FlagType};
+use clap::{crate_version, App, Arg, SubCommand};
 use std::env;
 use version::{Bump, Version};
 
 #[cfg(not(tarpaulin_include))]
 fn main() {
-    let args: Vec<String> = env::args().collect();
-
-    // common flags
-    let pre_release_flag = Flag::new("pre", FlagType::String).description("Use a pre-release tag.");
-    let config_file_flag = Flag::new("config", FlagType::String)
-        .description("Select config file to use. Default is `Config.toml`.");
-
-    let app = App::new(env!("CARGO_PKG_NAME"))
-        .description(env!("CARGO_PKG_DESCRIPTION"))
+    let matches = App::new("cargo-semver")
+        .version(crate_version!())
         .author(env!("CARGO_PKG_AUTHORS"))
-        .version(env!("CARGO_PKG_VERSION"))
-        .usage("cargo-semver")
-        .action(default_action)
-        .flag(config_file_flag.clone())
-        .command(
-            Command::new("set")
-                .description("Set the version in Cargo.toml")
+        .about(env!("CARGO_PKG_DESCRIPTION"))
+        .arg(
+            Arg::with_name("config")
+                .short("c")
+                .long("config")
+                .value_name("FILE")
+                .help("Use a custom config file")
+                .takes_value(true)
+                .global(true),
+        )
+        .subcommand(
+            SubCommand::with_name("set")
+                .about("Set a specific version")
                 .usage("cargo-semver set [VERSION]")
-                .action(set_action)
-                .flag(config_file_flag.clone()),
+                .arg(
+                    Arg::with_name("VERSION")
+                        .help("A semantic version")
+                        .required(true)
+                        .index(1),
+                ),
         )
-        .command(
-            Command::new("patch")
-                .description("Increments the patch version number in Cargo.toml")
-                .usage("cargo-semver patch")
-                .action(patch_action)
-                .flag(pre_release_flag.clone())
-                .flag(config_file_flag.clone()),
+        .subcommand(
+            SubCommand::with_name("bump")
+                .about("Increments the version number")
+                .usage("cargo-semver bump [TYPE] [PRE-RELEASE]")
+                .arg(
+                    Arg::with_name("TYPE")
+                        .required(true)
+                        .index(1)
+                        .possible_values(&["major", "minor", "patch", "pre"])
+                        .help("Increment type"),
+                )
+                .arg(
+                    Arg::with_name("PRE-RELEASE")
+                        .required(false)
+                        .index(2)
+                        .help("Add a pre-release version (optional)"),
+                ),
         )
-        .command(
-            Command::new("minor")
-                .description("Increments the minor version number in Cargo.toml")
-                .usage("cargo-semver minor")
-                .action(minor_action)
-                .flag(pre_release_flag.clone())
-                .flag(config_file_flag.clone()),
-        )
-        .command(
-            Command::new("major")
-                .description("Increments the major version number in Cargo.toml")
-                .usage("cargo-semver major")
-                .action(major_action)
-                .flag(pre_release_flag)
-                .flag(config_file_flag.clone()),
-        )
-        .command(
-            Command::new("pre")
-                .description("Increments the pre-release version number in Cargo.toml")
-                .usage("cargo-semver pre [alpha|beta]")
-                .action(pre_action)
-                .flag(config_file_flag),
-        );
+        .get_matches();
 
-    app.run(args);
-}
+    // create a version from the config file
+    let config_path = matches.value_of("config").unwrap_or("Cargo.toml");
+    let mut version = Version::new(config_path);
 
-/// The default `cargo-semver` commands returns the
-/// current version set in `Config.toml`.
-fn default_action(c: &Context) {
-    let version = Version::new(c);
+    // $ cargo semver set x.x.x
+    if let Some(matches) = matches.subcommand_matches("set") {
+        let value = matches.value_of("VERSION").unwrap();
+        let new_version = version.set(value);
+        println!("{}", new_version);
 
+        return;
+    }
+
+    // $ cargo semver bump major|minor|patch|pre
+    if let Some(matches) = matches.subcommand_matches("bump") {
+        let mut pre_arg = match matches.value_of("PRE-RELEASE") {
+            Some(arg) => Some(arg),
+            None => None,
+        };
+
+        let bump = match matches.value_of("TYPE") {
+            Some("major") => Bump::Major,
+            Some("minor") => Bump::Minor,
+            Some("patch") => Bump::Patch,
+            Some("pre") => {
+                // use pre in bump and then set it to none
+                // so we don't get the pre-release logic for the other bumps
+                let pre = pre_arg.unwrap_or("").to_string();
+                pre_arg = None;
+                Bump::Pre(pre)
+            }
+            _ => panic!("invalid [TYPE] argument"),
+        };
+
+        let new_version = version.bump(bump, pre_arg);
+        println!("{}", new_version);
+
+        return;
+    }
+
+    // no subcommand so just print the version
     println!("{}", version.version);
-}
-
-fn set_version(c: &Context, version_arg: &str) -> String {
-    let mut version = Version::new(c);
-
-    let new_version = match version_arg {
-        v => match semver::Version::parse(&v) {
-            Ok(v) => v,
-            Err(err) => panic!("{}", err),
-        },
-    };
-
-    let new_version = version.set(new_version);
-    println!("{}", new_version);
-    new_version
-}
-
-fn bump_version(c: &Context, bump: Bump) -> String {
-    let mut version = Version::new(c);
-
-    let pre_flag = match c.string_flag("pre") {
-        Ok(flag) => Some(flag),
-        _ => None,
-    };
-
-    let new_version = version.bump(bump, pre_flag);
-    println!("{}", new_version);
-    new_version
-}
-
-/// Set the version in `Config.toml` to the `VALUE` input
-/// in `cargo-semver set [VERSION]`.
-fn set_action(c: &Context) {
-    // the new version argument
-    let version_arg = c.args.join(" ");
-
-    set_version(c, &version_arg);
-}
-
-/// Increments the patch version number.
-fn patch_action(c: &Context) {
-    bump_version(c, Bump::Patch);
-}
-
-/// Increments the minor version number.
-fn minor_action(c: &Context) {
-    bump_version(c, Bump::Minor);
-}
-
-/// Increments the major version number.
-fn major_action(c: &Context) {
-    bump_version(c, Bump::Major);
-}
-
-/// Increments the pre-release version number.
-fn pre_action(c: &Context) {
-    let value = c.args.join(" ");
-    bump_version(c, Bump::Pre(value));
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use predicates::prelude::*;
-    use seahorse::{Context, Flag, FlagType};
-    use std::{fs, io::Write};
-    use tempfile::NamedTempFile;
-
-    fn setup_test_context(
-        file: &mut NamedTempFile,
-        version: &str,
-        extra_args: &mut Vec<String>,
-    ) -> Context {
-        let file_has_content = file.as_file().metadata().unwrap().len() > 0;
-        if !file_has_content {
-            writeln!(
-                file,
-                "[package]\nversion = \"{}\"\n\n[dependencies]\nversion = \"{}\"",
-                version, version,
-            )
-            .unwrap();
-        }
-
-        let config_path = file.path().to_str().unwrap().to_string();
-        let config_flag = Flag::new("config", FlagType::String);
-        let pre_flag = Flag::new("pre", FlagType::String);
-
-        let mut args = vec!["--config".to_string(), config_path];
-        args.append(extra_args);
-
-        Context::new(args, Some(vec![config_flag, pre_flag]), "".to_string())
-    }
-
-    fn get_file_path(file: &mut NamedTempFile) -> String {
-        file.path().to_str().unwrap().to_string()
-    }
-
-    #[test]
-    fn test_bump_version() {
-        let mut file = NamedTempFile::new().unwrap();
-        let context = setup_test_context(&mut file, "1.0.0", &mut vec![]);
-        let path = get_file_path(&mut file);
-
-        major_action(&context);
-        let contains = predicate::str::contains("2.0.0");
-        assert_eq!(true, contains.eval(&fs::read_to_string(&path).unwrap()));
-
-        minor_action(&context);
-        let contains = predicate::str::contains("2.1.0");
-        assert_eq!(true, contains.eval(&fs::read_to_string(&path).unwrap()));
-
-        patch_action(&context);
-        let contains = predicate::str::contains("2.1.1");
-        assert_eq!(true, contains.eval(&fs::read_to_string(&path).unwrap()));
-
-        let new_context = setup_test_context(&mut file, "0", &mut vec!["alpha".to_string()]);
-        pre_action(&new_context);
-        let contains = predicate::str::contains("2.1.1-alpha.1");
-        assert_eq!(true, contains.eval(&fs::read_to_string(&path).unwrap()));
-
-        pre_action(&new_context);
-        let contains = predicate::str::contains("2.1.1-alpha.2");
-        assert_eq!(true, contains.eval(&fs::read_to_string(&path).unwrap()));
-
-        let new_context = setup_test_context(&mut file, "0", &mut vec!["beta".to_string()]);
-        pre_action(&new_context);
-        let contains = predicate::str::contains("2.1.1-beta.1");
-        assert_eq!(true, contains.eval(&fs::read_to_string(&path).unwrap()));
-
-        let new_context = setup_test_context(
-            &mut file,
-            "0",
-            &mut vec!["--pre".to_string(), "beta".to_string()],
-        );
-        major_action(&new_context);
-        let contains = predicate::str::contains("3.0.0-beta.1");
-        assert_eq!(true, contains.eval(&fs::read_to_string(&path).unwrap()));
-
-        major_action(&context);
-        let contains = predicate::str::contains("4.0.0");
-        assert_eq!(true, contains.eval(&fs::read_to_string(&path).unwrap()));
-
-        let new_context = setup_test_context(&mut file, "0", &mut vec!["1.5.0".to_string()]);
-        set_action(&new_context);
-        let contains = predicate::str::contains("1.5.0");
-        assert_eq!(true, contains.eval(&fs::read_to_string(&path).unwrap()));
-    }
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -34,7 +34,7 @@ fn get() {
 #[test]
 fn patch() {
     let mut file = NamedTempFile::new().unwrap();
-    let (mut cmd, path) = setup_command(&mut file, "1.0.0", vec!["patch"]);
+    let (mut cmd, path) = setup_command(&mut file, "1.0.0", vec!["bump", "patch"]);
     cmd.assert().success().stdout("1.0.1\n");
 
     let contains = predicate::str::contains("1.0.1");
@@ -44,7 +44,7 @@ fn patch() {
 #[test]
 fn minor() {
     let mut file = NamedTempFile::new().unwrap();
-    let (mut cmd, path) = setup_command(&mut file, "1.0.0", vec!["minor"]);
+    let (mut cmd, path) = setup_command(&mut file, "1.0.0", vec!["bump", "minor"]);
     cmd.assert().success().stdout("1.1.0\n");
 
     let contains = predicate::str::contains("1.1.0");
@@ -54,7 +54,7 @@ fn minor() {
 #[test]
 fn major() {
     let mut file = NamedTempFile::new().unwrap();
-    let (mut cmd, path) = setup_command(&mut file, "1.0.0", vec!["major"]);
+    let (mut cmd, path) = setup_command(&mut file, "1.0.0", vec!["bump", "major"]);
     cmd.assert().success().stdout("2.0.0\n");
 
     let contains = predicate::str::contains("2.0.0");
@@ -64,7 +64,7 @@ fn major() {
 #[test]
 fn major_pre() {
     let mut file = NamedTempFile::new().unwrap();
-    let (mut cmd, path) = setup_command(&mut file, "1.0.0", vec!["major", "--pre", "alpha"]);
+    let (mut cmd, path) = setup_command(&mut file, "1.0.0", vec!["bump", "major", "alpha"]);
     cmd.assert().success().stdout("2.0.0-alpha.1\n");
 
     let contains = predicate::str::contains("2.0.0-alpha.1");
@@ -74,21 +74,21 @@ fn major_pre() {
 #[test]
 fn pre() {
     let mut file = NamedTempFile::new().unwrap();
-    let (mut cmd, path) = setup_command(&mut file, "1.0.0", vec!["pre", "alpha"]);
+    let (mut cmd, path) = setup_command(&mut file, "1.0.0", vec!["bump", "pre", "alpha"]);
     cmd.assert().success().stdout("1.0.0-alpha.1\n");
 
     let contains = predicate::str::contains("1.0.0-alpha.1");
     assert_eq!(true, contains.eval(&fs::read_to_string(path).unwrap()));
 
     // run again without `alpha`
-    let (mut cmd, path) = setup_command(&mut file, "1.0.0", vec!["pre"]);
+    let (mut cmd, path) = setup_command(&mut file, "1.0.0", vec!["bump", "pre"]);
     cmd.assert().success().stdout("1.0.0-alpha.2\n");
 
     let contains = predicate::str::contains("1.0.0-alpha.2");
     assert_eq!(true, contains.eval(&fs::read_to_string(path).unwrap()));
 
     // change to `beta`
-    let (mut cmd, path) = setup_command(&mut file, "1.0.0", vec!["pre", "beta"]);
+    let (mut cmd, path) = setup_command(&mut file, "1.0.0", vec!["bump", "pre", "beta"]);
     cmd.assert().success().stdout("1.0.0-beta.1\n");
 
     let contains = predicate::str::contains("1.0.0-beta.1");
@@ -98,7 +98,7 @@ fn pre() {
 #[test]
 fn keep_dependency_version() {
     let mut file = NamedTempFile::new().unwrap();
-    let (mut cmd, path) = setup_command(&mut file, "1.0.0", vec!["major"]);
+    let (mut cmd, path) = setup_command(&mut file, "1.0.0", vec!["bump", "major"]);
     cmd.assert().success().stdout("2.0.0\n");
 
     let contains = predicate::str::contains("version = \"2.0.0\"");
@@ -122,7 +122,7 @@ fn bad_input() {
 #[test]
 fn missing_pre_version() {
     let mut file = NamedTempFile::new().unwrap();
-    let (mut cmd, path) = setup_command(&mut file, "1.0.0", vec!["pre"]);
+    let (mut cmd, path) = setup_command(&mut file, "1.0.0", vec!["bump", "pre"]);
     cmd.assert().failure().stderr(predicate::str::contains(
         "run `cargo-semver pre [alpha|beta]` first to add a new pre-release version.",
     ));


### PR DESCRIPTION
### What this PR is about:

I picked the previous argument parser (seahorse) becaue it was small and didn't have any dependecies, but it didn't work well when running under the `cargo` cli (`cargo-semver major` worked but not `cargo semver major`). This PR moves this project to [clap](https://github.com/clap-rs/clap), and with that I also made some changes to the API that was enabled by this switch:

```diff
- cargo semver major|minor|patch|pre
+ cargo semver bump major|minor|patch|pre

- cargo semver major --pre alpha
+ cargo semver bump major alpha
```