### PR TITLE
feat: cargo subcommand

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -39,6 +39,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: run
+          args: semver get
 
       - name: upload to codecov.io
         uses: codecov/codecov-action@v1.0.2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,7 +56,7 @@ checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
 name = "cargo-semver"
-version = "1.0.0-alpha.2"
+version = "1.0.0-alpha.3"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Filip Stefansson <filip.stefansson@gmail.com>"]
 name = "cargo-semver"
-version = "1.0.0-alpha.2"
+version = "1.0.0-alpha.3"
 license = "MIT"
 description = "Cargo subcommand to update the version in your Cargo.toml file - SemVer style."
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@
 [![crates.io](https://img.shields.io/crates/v/cargo-semver)](https://crates.io/crates/cargo-semver)
 [![codecov](https://codecov.io/gh/filipstefansson/cargo-semver/branch/master/graph/badge.svg?token=HSAldVxPvX)](https://codecov.io/gh/filipstefansson/cargo-semver)
 
-**cargo-semver** is a cargo subcommand to help you update the version in your `Cargo.toml` file.
+**cargo-semver** is a cargo subcommand to help you read and update the version in your `Cargo.toml` file.
 
 ```console
-$ cargo semver
+$ cargo semver get
 1.0.0
 
 $ cargo semver bump patch
@@ -24,9 +24,14 @@ $ cargo install cargo-semver
 ## Usage
 
 ```console
-$ cargo semver # gets the current version
-$ cargo semver bump [TYPE] [PRE-RELEASE] # bumps the version
-$ cargo set [VERSION] # sets a specific version
+# get the current version
+$ cargo semver get
+
+# bump the version with an optional pre-release
+$ cargo semver bump [TYPE] [PRE-RELEASE]
+
+# set a specific version
+$ cargo set [VERSION]
 ```
 
 ### Update version

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,8 +14,7 @@ fn main() {
             SubCommand::with_name("semver")
                 .version(crate_version!())
                 .bin_name("cargo")
-                .author(env!("CARGO_PKG_AUTHORS"))
-                .about(env!("CARGO_PKG_DESCRIPTION"))
+                .about("Read or update the version in your Cargo.toml file")
                 .setting(AppSettings::ArgRequiredElseHelp)
                 .arg(
                     Arg::with_name("config")

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,55 +1,66 @@
 mod config;
 mod version;
 
-use clap::{crate_version, App, Arg, SubCommand};
+use clap::{crate_version, App, AppSettings, Arg, SubCommand};
 use std::env;
 use version::{Bump, Version};
 
 #[cfg(not(tarpaulin_include))]
 fn main() {
+    // create a sub command for cargo
     let matches = App::new("cargo-semver")
         .version(crate_version!())
-        .author(env!("CARGO_PKG_AUTHORS"))
-        .about(env!("CARGO_PKG_DESCRIPTION"))
-        .arg(
-            Arg::with_name("config")
-                .short("c")
-                .long("config")
-                .value_name("FILE")
-                .help("Use a custom config file")
-                .takes_value(true)
-                .global(true),
-        )
         .subcommand(
-            SubCommand::with_name("set")
-                .about("Set a specific version")
-                .usage("cargo-semver set [VERSION]")
+            SubCommand::with_name("semver")
+                .version(crate_version!())
+                .bin_name("cargo")
+                .author(env!("CARGO_PKG_AUTHORS"))
+                .about(env!("CARGO_PKG_DESCRIPTION"))
+                .setting(AppSettings::ArgRequiredElseHelp)
+                .setting(AppSettings::TrailingVarArg)
                 .arg(
-                    Arg::with_name("VERSION")
-                        .help("A semantic version")
-                        .required(true)
-                        .index(1),
-                ),
-        )
-        .subcommand(
-            SubCommand::with_name("bump")
-                .about("Increments the version number")
-                .usage("cargo-semver bump [TYPE] [PRE-RELEASE]")
-                .arg(
-                    Arg::with_name("TYPE")
-                        .required(true)
-                        .index(1)
-                        .possible_values(&["major", "minor", "patch", "pre"])
-                        .help("Increment type"),
+                    Arg::with_name("config")
+                        .short("c")
+                        .long("config")
+                        .value_name("FILE")
+                        .help("Use a custom config file")
+                        .takes_value(true)
+                        .global(true),
                 )
-                .arg(
-                    Arg::with_name("PRE-RELEASE")
-                        .required(false)
-                        .index(2)
-                        .help("Add a pre-release version (optional)"),
+                .subcommand(
+                    SubCommand::with_name("set")
+                        .about("Set a specific version")
+                        .usage("cargo-semver set [VERSION]")
+                        .arg(
+                            Arg::with_name("VERSION")
+                                .help("A semantic version")
+                                .required(true)
+                                .index(1),
+                        ),
+                )
+                .subcommand(
+                    SubCommand::with_name("bump")
+                        .about("Increments the version number")
+                        .usage("cargo-semver bump [TYPE] [PRE-RELEASE]")
+                        .arg(
+                            Arg::with_name("TYPE")
+                                .required(true)
+                                .index(1)
+                                .possible_values(&["major", "minor", "patch", "pre"])
+                                .help("Increment type"),
+                        )
+                        .arg(
+                            Arg::with_name("PRE-RELEASE")
+                                .required(false)
+                                .index(2)
+                                .help("Add a pre-release version (optional)"),
+                        ),
                 ),
         )
         .get_matches();
+
+    // go down one sub command level from `cargo semver` to just `semver`
+    let matches = matches.subcommand_matches("semver").unwrap();
 
     // create a version from the config file
     let config_path = matches.value_of("config").unwrap_or("Cargo.toml");

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,6 @@ fn main() {
                 .author(env!("CARGO_PKG_AUTHORS"))
                 .about(env!("CARGO_PKG_DESCRIPTION"))
                 .setting(AppSettings::ArgRequiredElseHelp)
-                .setting(AppSettings::TrailingVarArg)
                 .arg(
                     Arg::with_name("config")
                         .short("c")
@@ -37,6 +36,11 @@ fn main() {
                                 .required(true)
                                 .index(1),
                         ),
+                )
+                .subcommand(
+                    SubCommand::with_name("get")
+                        .about("Prints the current version")
+                        .usage("cargo-semver get"),
                 )
                 .subcommand(
                     SubCommand::with_name("bump")
@@ -65,6 +69,12 @@ fn main() {
     // create a version from the config file
     let config_path = matches.value_of("config").unwrap_or("Cargo.toml");
     let mut version = Version::new(config_path);
+
+    // $ cargo semver get
+    if matches.subcommand_matches("get").is_some() {
+        println!("{}", version.version);
+        return;
+    }
 
     // $ cargo semver set x.x.x
     if let Some(matches) = matches.subcommand_matches("set") {
@@ -101,7 +111,4 @@ fn main() {
 
         return;
     }
-
-    // no subcommand so just print the version
-    println!("{}", version.version);
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -15,8 +15,10 @@ fn setup_command(file: &mut NamedTempFile, version: &str, command: Vec<&str>) ->
     let path = file.path().to_str().unwrap();
 
     let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
-    cmd.args(command);
+
+    cmd.args(vec!["semver"]);
     cmd.arg("--config").arg(path);
+    cmd.args(command);
 
     (cmd, path.to_string())
 }
@@ -24,7 +26,7 @@ fn setup_command(file: &mut NamedTempFile, version: &str, command: Vec<&str>) ->
 #[test]
 fn get() {
     let mut file = NamedTempFile::new().unwrap();
-    let (mut cmd, path) = setup_command(&mut file, "1.0.0", vec![]);
+    let (mut cmd, path) = setup_command(&mut file, "1.0.0", vec!["get"]);
     cmd.assert().success().stdout("1.0.0\n");
 
     let contains = predicate::str::contains("1.0.0");


### PR DESCRIPTION
### What this PR is about:

- Make `semver` a subcommand of `cargo`
- Add `get` command for reading version
- Make the default `cargo semver` command show `--help`:

```diff
- $ cargo semver
- 1.0.0
+ $ cargo semver get
+ 1.0.0
```